### PR TITLE
IEEE: do not use the termes font for ieeeconf and ieeetran

### DIFF
--- a/styles/article/ieee/ieeeconf.ts
+++ b/styles/article/ieee/ieeeconf.ts
@@ -1,4 +1,4 @@
-<TeXmacs|1.99.19>
+<TeXmacs|2.1.2>
 
 <style|source>
 
@@ -24,7 +24,7 @@
     </src-title>
   </active*>
 
-  <use-package|article|std-latex|two-columns|termes-font>
+  <use-package|article|std-latex|two-columns>
 
   <active*|<src-comment|Global style parameters>>
 

--- a/styles/article/ieee/ieeetran.ts
+++ b/styles/article/ieee/ieeetran.ts
@@ -1,4 +1,4 @@
-<TeXmacs|1.99.19>
+<TeXmacs|2.1.2>
 
 <style|source>
 
@@ -24,11 +24,9 @@
     </src-title>
   </active*>
 
-  <use-package|article|std-latex|two-columns|termes-font>
+  <use-package|article|std-latex|two-columns>
 
   <active*|<src-comment|Global style parameters>>
-
-  <assign|font|math=roman,termes>
 
   <assign|par-sep|0.2fn>
 


### PR DESCRIPTION
## Why
Because termes font is not built-in in Mogan. There will be font issues if we use the missing font.